### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "convexpress": "^1.3.3",
     "express-jwt": "^3.3.0",
     "jsonwebtoken": "^5.5.0",
-    "node-uuid": "^1.4.7"
+    "uuid": "^3.0.0"
   }
 }

--- a/src/convroutes/create-user.js
+++ b/src/convroutes/create-user.js
@@ -1,5 +1,5 @@
 import {randomBytes} from "crypto";
-import {v4} from "node-uuid";
+import {v4} from "uuid";
 
 import {hash} from "./utils/bcrypt";
 import * as authorize from "./middleware/authorize";

--- a/src/convroutes/login.js
+++ b/src/convroutes/login.js
@@ -1,5 +1,5 @@
 import {sign} from "jsonwebtoken";
-import {v4} from "node-uuid";
+import {v4} from "uuid";
 
 import {compare} from "./utils/bcrypt";
 


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.